### PR TITLE
12.4.2024 Bug fixes to maintain diagnostic paper workflow

### DIFF
--- a/pywrdrb/make_figs_diagnostics_paper.py
+++ b/pywrdrb/make_figs_diagnostics_paper.py
@@ -162,9 +162,11 @@ if __name__ == "__main__":
             datetime_index=datetime_index,
             units=units,
         )
+        reservoir_downstream_gages[model] = reservoir_downstream_gages[model][0]
         reservoir_downstream_gages[model]["NYCAgg"] = reservoir_downstream_gages[model][
             reservoir_list_nyc
         ].sum(axis=1)
+
         major_flows[model], datetime_index = get_base_results(
             input_dir,
             model,
@@ -172,6 +174,7 @@ if __name__ == "__main__":
             datetime_index=datetime_index,
             units=units,
         )
+        major_flows[model] = major_flows[model][0]
 
     ### different time periods for different type of figures.
     start_date_obs = pd.to_datetime(

--- a/pywrdrb/make_model.py
+++ b/pywrdrb/make_model.py
@@ -100,8 +100,8 @@ def add_major_node(
     variable_cost=None,
     has_catchment=True,
     inflow_ensemble_indices=None,
-    run_starfit_sensitivity_analysis=True,
-    sensitivity_analysis_scenarios= list(range(0, 2001))
+    run_starfit_sensitivity_analysis=False,
+    sensitivity_analysis_scenarios=list(range(0, 2001)),
 ):
     """
     Add a major node to the model.
@@ -293,7 +293,7 @@ def add_major_node(
             "type": "STARFITReservoirRelease",
             "node": name,
             "run_starfit_sensitivity_analysis": run_starfit_sensitivity_analysis,
-            "sensitivity_analysis_scenarios" : sensitivity_analysis_scenarios,
+            "sensitivity_analysis_scenarios": sensitivity_analysis_scenarios,
         }
 
     if has_catchment:
@@ -367,8 +367,8 @@ def make_model(
     inflow_ensemble_indices=None,
     predict_temperature=False,
     predict_salinity=False,
-    run_starfit_sensitivity_analysis=True,
-    sensitivity_analysis_scenarios=list(range(0, 2001))
+    run_starfit_sensitivity_analysis=False,
+    sensitivity_analysis_scenarios=list(range(0, 2001)),
 ):
     """
     Creates the JSON file used by Pywr to define the model, including all nodes, edges, and parameters.
@@ -383,7 +383,7 @@ def make_model(
         predict_salinity (bool): If True, use LSTM model to predict salinity. NOT YET IMPLEMENTED.
         run_starfit_sensitivity_analysis (bool): If True, run STARFIT sensitivity analysis. Default is False.
         sensitivity_analysis_scenarios (list): List of scenario ID numbers for STARFIT sensitivity analysis.
-    
+
     Returns:
         dict: Model JSON representation.
     """
@@ -917,7 +917,9 @@ def make_model(
                 "index_col": "datetime",
                 "parse_dates": True,
             }
-        print('WARNING: Ensemble mode not tested/verified for Montague & Trenton flow forecasts')
+        print(
+            "WARNING: Ensemble mode not tested/verified for Montague & Trenton flow forecasts"
+        )
 
     ### Get total release needed from NYC reservoirs to satisfy Montague & Trenton flow targets,
     ### above and beyond their individually mandated releases, & after accting for non-NYC inflows and NJ diversions.

--- a/pywrdrb/parameters/starfit.py
+++ b/pywrdrb/parameters/starfit.py
@@ -13,15 +13,16 @@ from pywrdrb.parameters.lower_basin_ffmp import conservation_releases, max_disch
 class STARFITReservoirRelease(Parameter):
     """
     Custom Pywr Parameter used to implement the STARFIT-inferred reservoir operations policy at non-NYC reservoirs following Turner et al. (2021).
-    
+
     Attributes:
         model (Model): The PywrDRB model.
         storage_node (str): The storage node associated with the reservoir.
         flow_parameter: The PywrDRB catchment inflow parameter corresponding to the reservoir.
-    
+
     Methods:
         value(timestep, scenario_index): returns the STARFIT-inferred reservoir release for the current timestep and scenario index
     """
+
     def __init__(
         self,
         model,
@@ -36,11 +37,8 @@ class STARFITReservoirRelease(Parameter):
 
         self.node = storage_node
         self.reservoir_name = reservoir_name
-        print(
-            f"Initialized STARFITReservoirRelease for reservoir: {self.reservoir_name}"
-        )
         self.inflow = flow_parameter
-        
+
         # Add children
         self.children.add(flow_parameter)
 
@@ -104,7 +102,7 @@ class STARFITReservoirRelease(Parameter):
 
         # Use modified storage parameters for DRBC relevant reservoirs
         if self.name in modified_starfit_reservoir_list:
-            self.starfit_name = 'modified_' + self.name
+            self.starfit_name = "modified_" + self.name
         else:
             self.starfit_name = self.reservoir_name
 
@@ -122,29 +120,27 @@ class STARFITReservoirRelease(Parameter):
             self.S_cap = starfit_params.loc[self.starfit_name, "GRanD_CAP_MG"]
             self.I_bar = starfit_params.loc[self.starfit_name, "GRanD_MEANFLOW_MGD"]
 
-
         # Store STARFIT parameters
-        self.NORhi_mu = starfit_params.loc[self.starfit_name, 'NORhi_mu']
-        self.NORhi_min = starfit_params.loc[self.starfit_name, 'NORhi_min']
-        self.NORhi_max = starfit_params.loc[self.starfit_name, 'NORhi_max']
-        self.NORhi_alpha = starfit_params.loc[self.starfit_name, 'NORhi_alpha']
-        self.NORhi_beta = starfit_params.loc[self.starfit_name, 'NORhi_beta']
-        
-        self.NORlo_mu = starfit_params.loc[self.starfit_name, 'NORlo_mu']
-        self.NORlo_min = starfit_params.loc[self.starfit_name, 'NORlo_min']
-        self.NORlo_max = starfit_params.loc[self.starfit_name, 'NORlo_max']
-        self.NORlo_alpha = starfit_params.loc[self.starfit_name, 'NORlo_alpha']
-        self.NORlo_beta = starfit_params.loc[self.starfit_name, 'NORlo_beta']
-        
-        self.Release_alpha1 = starfit_params.loc[self.starfit_name, 'Release_alpha1']
-        self.Release_alpha2 = starfit_params.loc[self.starfit_name, 'Release_alpha2']
-        self.Release_beta1 = starfit_params.loc[self.starfit_name, 'Release_beta1']
-        self.Release_beta2 = starfit_params.loc[self.starfit_name, 'Release_beta2']
-        
-        self.Release_c = starfit_params.loc[self.starfit_name, 'Release_c']
-        self.Release_p1 = starfit_params.loc[self.starfit_name, 'Release_p1']
-        self.Release_p2 = starfit_params.loc[self.starfit_name, 'Release_p2']
-        
+        self.NORhi_mu = starfit_params.loc[self.starfit_name, "NORhi_mu"]
+        self.NORhi_min = starfit_params.loc[self.starfit_name, "NORhi_min"]
+        self.NORhi_max = starfit_params.loc[self.starfit_name, "NORhi_max"]
+        self.NORhi_alpha = starfit_params.loc[self.starfit_name, "NORhi_alpha"]
+        self.NORhi_beta = starfit_params.loc[self.starfit_name, "NORhi_beta"]
+
+        self.NORlo_mu = starfit_params.loc[self.starfit_name, "NORlo_mu"]
+        self.NORlo_min = starfit_params.loc[self.starfit_name, "NORlo_min"]
+        self.NORlo_max = starfit_params.loc[self.starfit_name, "NORlo_max"]
+        self.NORlo_alpha = starfit_params.loc[self.starfit_name, "NORlo_alpha"]
+        self.NORlo_beta = starfit_params.loc[self.starfit_name, "NORlo_beta"]
+
+        self.Release_alpha1 = starfit_params.loc[self.starfit_name, "Release_alpha1"]
+        self.Release_alpha2 = starfit_params.loc[self.starfit_name, "Release_alpha2"]
+        self.Release_beta1 = starfit_params.loc[self.starfit_name, "Release_beta1"]
+        self.Release_beta2 = starfit_params.loc[self.starfit_name, "Release_beta2"]
+
+        self.Release_c = starfit_params.loc[self.starfit_name, "Release_c"]
+        self.Release_p1 = starfit_params.loc[self.starfit_name, "Release_p1"]
+        self.Release_p2 = starfit_params.loc[self.starfit_name, "Release_p2"]
 
         # Override STARFIT max releases at DRBC lower reservoirs
         if self.reservoir_name in list(max_discharges.keys()):
@@ -168,7 +164,6 @@ class STARFITReservoirRelease(Parameter):
                 starfit_params.loc[self.starfit_name, "Release_min"] + 1
             ) * self.I_bar
 
-
     def setup(self):
         """
         Set up the parameter.
@@ -176,7 +171,7 @@ class STARFITReservoirRelease(Parameter):
         super().setup()
         self.N_SCENARIOS = len(self.model.scenarios.combinations)
         self.releases = np.empty([self.N_SCENARIOS], np.float64)
-        
+
     def standardize_inflow(self, inflow):
         """
         Standardize the current reservoir inflow based on historic average.
@@ -187,8 +182,8 @@ class STARFITReservoirRelease(Parameter):
         Returns:
             float: The standardized inflow value.
         """
-        return (inflow - self.I_bar) / self.I_bar        
-    
+        return (inflow - self.I_bar) / self.I_bar
+
     def calculate_percent_storage(self, storage):
         """
         Calculate the reservoir's current percentage of storage capacity.
@@ -199,8 +194,8 @@ class STARFITReservoirRelease(Parameter):
         Returns:
             float: The percentage of storage capacity.
         """
-        return (storage / self.S_cap)
-    
+        return storage / self.S_cap
+
     def get_NORhi(self, timestep):
         """
         Get the upper-bound normalized reservoir storage of the Normal Operating Range (NORlo) for a given timestep.
@@ -211,16 +206,19 @@ class STARFITReservoirRelease(Parameter):
         Returns:
             float: The NORhi value.
         """
-        c = math.pi*(timestep.dayofyear + self.WATER_YEAR_OFFSET)/365  
-        NORhi = (self.NORhi_mu + self.NORhi_alpha * math.sin(2*c) +
-                 self.NORhi_beta * math.cos(2*c))
+        c = math.pi * (timestep.dayofyear + self.WATER_YEAR_OFFSET) / 365
+        NORhi = (
+            self.NORhi_mu
+            + self.NORhi_alpha * math.sin(2 * c)
+            + self.NORhi_beta * math.cos(2 * c)
+        )
         if (NORhi <= self.NORhi_max) and (NORhi >= self.NORhi_min):
-            return NORhi/100
-        elif (NORhi > self.NORhi_max):
-            return self.NORhi_max/100
+            return NORhi / 100
+        elif NORhi > self.NORhi_max:
+            return self.NORhi_max / 100
         else:
-            return self.NORhi_min/100
-        
+            return self.NORhi_min / 100
+
     def get_NORlo(self, timestep):
         """
         Get the lower-bound normalized reservoir storage of the Normal Operating Range (NORlo) for a given timestep.
@@ -231,16 +229,19 @@ class STARFITReservoirRelease(Parameter):
         Returns:
             float: The NORlo value.
         """
-        c = math.pi*(timestep.dayofyear + self.WATER_YEAR_OFFSET)/365
-        NORlo = (self.NORlo_mu + self.NORlo_alpha * math.sin(2*c) +
-                 self.NORlo_beta * math.cos(2*c))
+        c = math.pi * (timestep.dayofyear + self.WATER_YEAR_OFFSET) / 365
+        NORlo = (
+            self.NORlo_mu
+            + self.NORlo_alpha * math.sin(2 * c)
+            + self.NORlo_beta * math.cos(2 * c)
+        )
         if (NORlo <= self.NORlo_max) and (NORlo >= self.NORlo_min):
-            return NORlo/100
-        elif (NORlo > self.NORlo_max):
-            return self.NORlo_max/100
+            return NORlo / 100
+        elif NORlo > self.NORlo_max:
+            return self.NORlo_max / 100
         else:
-            return self.NORlo_min/100 
-        
+            return self.NORlo_min / 100
+
     def get_harmonic_release(self, timestep):
         """
         Get the harmonic release for a given timestep.
@@ -251,13 +252,16 @@ class STARFITReservoirRelease(Parameter):
         Returns:
             float: The seasonal harmonic reservoir release (MGD).
         """
-        c = math.pi*(timestep.dayofyear + self.WATER_YEAR_OFFSET)/365
-        R_avg_t = self.Release_alpha1*math.sin(2*c) + self.Release_alpha2*math.sin(4*c) + self.Release_beta1*math.cos(2*c) + self.Release_beta2*math.cos(4*c)
+        c = math.pi * (timestep.dayofyear + self.WATER_YEAR_OFFSET) / 365
+        R_avg_t = (
+            self.Release_alpha1 * math.sin(2 * c)
+            + self.Release_alpha2 * math.sin(4 * c)
+            + self.Release_beta1 * math.cos(2 * c)
+            + self.Release_beta2 * math.cos(4 * c)
+        )
         return R_avg_t
 
-
-    def calculate_release_adjustment(self, S_hat, I_hat,
-                                     NORhi_t, NORlo_t):
+    def calculate_release_adjustment(self, S_hat, I_hat, NORhi_t, NORlo_t):
         """
         Calculate the release adjustment.
 
@@ -274,10 +278,10 @@ class STARFITReservoirRelease(Parameter):
         A_t = (S_hat - NORlo_t) / (NORhi_t)
         epsilon_t = self.Release_c + self.Release_p1 * A_t + self.Release_p2 * I_hat
         return epsilon_t
-    
-    
-    def calculate_target_release(self, harmonic_release, epsilon,
-                                 NORhi, NORlo, S_hat, I):
+
+    def calculate_target_release(
+        self, harmonic_release, epsilon, NORhi, NORlo, S_hat, I
+    ):
         """
         Calculate the target release under current inflow and storage.
 
@@ -293,12 +297,16 @@ class STARFITReservoirRelease(Parameter):
             float: The target release value.
         """
         if (S_hat <= NORhi) and (S_hat >= NORlo):
-            target = min((self.I_bar * (harmonic_release + epsilon) + self.I_bar), self.R_max)
-        elif (S_hat > NORhi):
-            target = min((self.S_cap * (S_hat - NORhi) + I*7)/7, self.R_max)
+            target = min(
+                (self.I_bar * (harmonic_release + epsilon) + self.I_bar), self.R_max
+            )
+        elif S_hat > NORhi:
+            target = min((self.S_cap * (S_hat - NORhi) + I * 7) / 7, self.R_max)
         else:
             if self.linear_below_NOR:
-                target = (self.I_bar * (harmonic_release + epsilon) + self.I_bar) * (S_hat / NORlo) #(1 - (NORlo - S_hat)/NORlo)
+                target = (self.I_bar * (harmonic_release + epsilon) + self.I_bar) * (
+                    S_hat / NORlo
+                )  # (1 - (NORlo - S_hat)/NORlo)
                 target = max(target, self.R_min)
             else:
                 target = self.R_min
@@ -336,7 +344,7 @@ class STARFITReservoirRelease(Parameter):
 
         elif not self.parameters_loaded and not self.run_sensitivity_analysis:
             self.starfit_params = self.load_default_starfit_params(model_data_dir)
-            print(f"Assigning STARFIT parameters for {self.reservoir_name}")
+            # print(f"Assigning STARFIT parameters for {self.reservoir_name}")
             self.assign_starfit_param_values(self.starfit_params)
             self.parameters_loaded = True
 
@@ -349,22 +357,24 @@ class STARFITReservoirRelease(Parameter):
 
         NORhi_t = self.get_NORhi(timestep)
         NORlo_t = self.get_NORlo(timestep)
-        
+
         seasonal_release_t = self.get_harmonic_release(timestep)
-            
+
         # Get adjustment from seasonal release
-        epsilon_t = self.calculate_release_adjustment(S_hat_t, 
-                                                      I_hat_t, 
-                                                      NORhi_t, NORlo_t)
-        
+        epsilon_t = self.calculate_release_adjustment(
+            S_hat_t, I_hat_t, NORhi_t, NORlo_t
+        )
+
         # Get target release
-        target_release = self.calculate_target_release(S_hat = S_hat_t,
-                                                    I = I_t,
-                                                    NORhi=NORhi_t,
-                                                    NORlo=NORlo_t,
-                                                    epsilon=epsilon_t,
-                                                    harmonic_release=seasonal_release_t)
-    
+        target_release = self.calculate_target_release(
+            S_hat=S_hat_t,
+            I=I_t,
+            NORhi=NORhi_t,
+            NORlo=NORlo_t,
+            epsilon=epsilon_t,
+            harmonic_release=seasonal_release_t,
+        )
+
         # Get actual release subject to constraints
         release_t = max(min(target_release, I_t + S_t), (I_t + S_t - self.S_cap))
 

--- a/pywrdrb/plotting/styles.py
+++ b/pywrdrb/plotting/styles.py
@@ -124,8 +124,10 @@ model_colors_diagnostics_paper3 = {
 
 model_label_dict = {
     "obs": "Observed",
-    "nhmv10": "NHMv1.0",
-    "nwmv21": "NWMv2.1",
+    "nhmv10": "NHM",
+    "nwmv21": "NWM",
+    "nhmv10_withObsScaled": "hNHM",
+    "nwmv21_withObsScaled": "hNWM",
     "obs_pub_nhmv10": "PUB-NHM",
     "obs_pub_nhmv10_ensemble": "PUB-NHM Ensemble",
     "obs_pub_nwmv21": "PUB-NWM",

--- a/pywrdrb_run_diagnostics_paper.sh
+++ b/pywrdrb_run_diagnostics_paper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=DRB_diagnostic
-#SBATCH --output=pywrdrb_diagnostic.out
-#SBATCH --error=pywrdrb_diagnostic.err
+#SBATCH --output=logs/pywrdrb_diagnostic.out
+#SBATCH --error=logs/pywrdrb_diagnostic.err
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --exclusive


### PR DESCRIPTION
- A few weeks ago I modified `get_base_results()` so that it matches the new output data structure (`result[model][scenario]`) used in the `Output` class.   This caused the issue in the `make_figs_diagnostic_paper.py`  which was using `get_base_results()` but expected the old structure.  
	- I simply added `reservoir_downstream_gages[model] = reservoir_downstream_gages[model][0]` to change the structure back to the old format while keeping `get_base_results()` the same.
	- Also did the same for the `major_flows` results.
- I had to add a minor change to `pywrdrb.plotting.styles.model_label_dict` because it was missing `"nhmv10_withObsScaled"` keys. 
- Lastly, I modified `run_historic_simulation.py` so that it uses `ModelBuilder` instead of `make_model`.
- Random:
	- Set `run_starfit_sensitivity_analysis=False` in `make_model`
	- Turned off print statements for Initalization and Assignment in `starfit.py` parameter